### PR TITLE
[Fix] Dots alignment when no decreasing dots are present

### DIFF
--- a/src/CarouselDots/styles.ts
+++ b/src/CarouselDots/styles.ts
@@ -4,6 +4,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'row',
+    alignItems: 'center',
   },
   scrollContainer: {
     alignItems: 'center',


### PR DESCRIPTION
In the case that the length of the items array is smaller than the minimum required to show the decreasing dots, the alignment is incorrect:
Before:
<img width="100" alt="Screenshot 2024-08-07 at 12 42 03" src="https://github.com/user-attachments/assets/67bd55d8-9776-44da-81ee-3e05acf505a8">
After:
<img width="100" alt="Screenshot 2024-08-07 at 12 42 25" src="https://github.com/user-attachments/assets/6f9cde7f-f0b8-4add-847d-ad3e5b7cef25">

Applying a `alignItems: 'center'` to the CarouselDots container style fixes the issue.